### PR TITLE
Resolves a race condition

### DIFF
--- a/index.js
+++ b/index.js
@@ -63,7 +63,7 @@ function syncMaps () {
   }
 
   on();
-  return function(){  off(); fns = []; };
+  return function(){  off(); fns = []; maps = []; };
 }
 
 module.exports = syncMaps;


### PR DESCRIPTION
This PR resolves a very strange race condition that isn't completely straightforward to reproduce.

It occurs when one of the 2 maps is resized while we are calling the `off` function to remove the syncing functionality. Stepping through the program reveals the following sequence:

1. The anonymous removal function is called:
    1. `off();` is called. This removes the event listeners from the maps.
    2. `fns = [];` is set
2. The `move` event resulting from the resize is processed. This somehow still has a reference to this plugin.
     1. `sync` is called
          1. `off();` is called. I believe calling `mapbox.off(`move', undefined)` is a noop, so this does nothing.
          2. `moveToMapPosition(master, clones);` is called.
          3. `on();` is called. This ends up calling `map[i].on(`move', fns[i])`, but since `fns === []` now, this is in effect `map[i].on(`move', undefined)`.
3. When the map moves for any reason, mapbox will attempt to call the event handler, but this is undefined, so we get a "Uncaught TypeError: Cannot read property 'call' of undefined".

I hope this sequence of events makes sense. It is possible that a more appropriate fix is in mapbox-gl itself, but the following simply nulls out the references to the maps, so any `on`/`off` calls in the future are simply noops.